### PR TITLE
osx: remove apple support from pkg

### DIFF
--- a/autosetup/autosetup-config.guess
+++ b/autosetup/autosetup-config.guess
@@ -446,12 +446,6 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
     *:*MiNT:*:* | *:*mint:*:* | *:*TOS:*:*)
 	echo m68k-unknown-mint"$UNAME_RELEASE"
 	exit ;;
-    m68k:machten:*:*)
-	echo m68k-apple-machten"$UNAME_RELEASE"
-	exit ;;
-    powerpc:machten:*:*)
-	echo powerpc-apple-machten"$UNAME_RELEASE"
-	exit ;;
     RISC*:Mach:*:*)
 	echo mips-dec-mach_bsd4.3
 	exit ;;
@@ -1208,9 +1202,6 @@ EOF
 	# From Paul.Green@stratus.com.
 	echo hppa1.1-stratus-vos
 	exit ;;
-    mc68*:A/UX:*:*)
-	echo m68k-apple-aux"$UNAME_RELEASE"
-	exit ;;
     news*:NEWS-OS:6*:*)
 	echo mips-sony-newsos6
 	exit ;;
@@ -1223,9 +1214,6 @@ EOF
 	exit ;;
     BeBox:BeOS:*:*)	# BeOS running on hardware made by Be, PPC only.
 	echo powerpc-be-beos
-	exit ;;
-    BeMac:BeOS:*:*)	# BeOS running on Mac or Mac clone, PPC only.
-	echo powerpc-apple-beos
 	exit ;;
     BePC:BeOS:*:*)	# BeOS running on Intel PC compatible.
 	echo i586-pc-beos
@@ -1256,48 +1244,6 @@ EOF
 	exit ;;
     SX-ACE:SUPER-UX:*:*)
 	echo sxace-nec-superux"$UNAME_RELEASE"
-	exit ;;
-    Power*:Rhapsody:*:*)
-	echo powerpc-apple-rhapsody"$UNAME_RELEASE"
-	exit ;;
-    *:Rhapsody:*:*)
-	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
-	exit ;;
-    *:Darwin:*:*)
-	UNAME_PROCESSOR=`uname -p` || UNAME_PROCESSOR=unknown
-	eval "$set_cc_for_build"
-	if test "$UNAME_PROCESSOR" = unknown ; then
-	    UNAME_PROCESSOR=powerpc
-	fi
-	if test "`echo "$UNAME_RELEASE" | sed -e 's/\..*//'`" -le 10 ; then
-	    if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
-		if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
-		       (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
-		       grep IS_64BIT_ARCH >/dev/null
-		then
-		    case $UNAME_PROCESSOR in
-			i386) UNAME_PROCESSOR=x86_64 ;;
-			powerpc) UNAME_PROCESSOR=powerpc64 ;;
-		    esac
-		fi
-		# On 10.4-10.6 one might compile for PowerPC via gcc -arch ppc
-		if (echo '#ifdef __POWERPC__'; echo IS_PPC; echo '#endif') | \
-		       (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
-		       grep IS_PPC >/dev/null
-		then
-		    UNAME_PROCESSOR=powerpc
-		fi
-	    fi
-	elif test "$UNAME_PROCESSOR" = i386 ; then
-	    # Avoid executing cc on OS X 10.9, as it ships with a stub
-	    # that puts up a graphical alert prompting to install
-	    # developer tools.  Any system running Mac OS X 10.7 or
-	    # later (Darwin 11 and later) is required to have a 64-bit
-	    # processor. This is not true of the ARM version of Darwin
-	    # that Apple uses in portable devices.
-	    UNAME_PROCESSOR=x86_64
-	fi
-	echo "$UNAME_PROCESSOR"-apple-darwin"$UNAME_RELEASE"
 	exit ;;
     *:procnto*:*:* | *:QNX:[0123456789]*:*)
 	UNAME_PROCESSOR=`uname -p`

--- a/autosetup/autosetup-config.guess
+++ b/autosetup/autosetup-config.guess
@@ -121,12 +121,6 @@ case $CC_FOR_BUILD,$HOST_CC,$CC in
  ,*,*)  CC_FOR_BUILD=$HOST_CC ;;
 esac ; set_cc_for_build= ;'
 
-# This is needed to find uname on a Pyramid OSx when run in the BSD universe.
-# (ghazi@noc.rutgers.edu 1994-08-24)
-if (test -f /.attbin/uname) >/dev/null 2>&1 ; then
-	PATH=$PATH:/.attbin ; export PATH
-fi
-
 UNAME_MACHINE=`(uname -m) 2>/dev/null` || UNAME_MACHINE=unknown
 UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
 UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
@@ -357,17 +351,6 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	exit ;;
     SR2?01:HI-UX/MPP:*:* | SR8000:HI-UX/MPP:*:*)
 	echo hppa1.1-hitachi-hiuxmpp
-	exit ;;
-    Pyramid*:OSx*:*:* | MIS*:OSx*:*:* | MIS*:SMP_DC-OSx*:*:*)
-	# akee@wpdis03.wpafb.af.mil (Earle F. Ake) contributed MIS and NILE.
-	if test "`(/bin/universe) 2>/dev/null`" = att ; then
-		echo pyramid-pyramid-sysv3
-	else
-		echo pyramid-pyramid-bsd
-	fi
-	exit ;;
-    NILE*:*:*:dcosx)
-	echo pyramid-pyramid-svr4
 	exit ;;
     DRS?6000:unix:4.0:6*)
 	echo sparc-icl-nx6
@@ -627,9 +610,6 @@ EOF
     ibmrt:*BSD:*|romp-ibm:BSD:*)            # covers RT/PC BSD and
 	echo romp-ibm-bsd"$UNAME_RELEASE"   # 4.3 with uname added to
 	exit ;;                             # report: romp-ibm BSD 4.3
-    *:BOSX:*:*)
-	echo rs6000-bull-bosx
-	exit ;;
     DPX/2?00:B.O.S.:*:*)
 	echo m68k-bull-sysv3
 	exit ;;

--- a/autosetup/autosetup-config.sub
+++ b/autosetup/autosetup-config.sub
@@ -635,10 +635,6 @@ case $basic_machine in
 		basic_machine=i586-pc
 		os=-msdosdjgpp
 		;;
-	dpx20 | dpx20-*)
-		basic_machine=rs6000-bull
-		os=-bosx
-		;;
 	dpx2*)
 		basic_machine=m68k-bull
 		os=-sysv3
@@ -1374,7 +1370,7 @@ case $os in
 	      | -hiux* | -knetbsd* | -mirbsd* | -netbsd* \
 	      | -bitrig* | -openbsd* | -solidbsd* | -libertybsd* \
 	      | -ekkobsd* | -kfreebsd* | -freebsd* | -riscix* | -lynxos* \
-	      | -bosx* | -nextstep* | -cxux* | -aout* | -elf* | -oabi* \
+		  | -cxux* | -aout* | -elf* | -oabi* \
 	      | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
 	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* | -hcos* \
 	      | -chorusos* | -chorusrdb* | -cegcc* | -glidix* \
@@ -1408,7 +1404,7 @@ case $os in
 		os=`echo $os | sed -e 's|nto|nto-qnx|'`
 		;;
 	-sim | -xray | -os68k* | -v88r* \
-	      | -windows* | -osx | -abug | -netware* | -os9* \
+	      | -windows* | -abug | -netware* | -os9* \
 	      | -macos* | -mpw* | -magic* | -mmixware* | -mon960* | -lnews*)
 		;;
 	-mac*)

--- a/autosetup/autosetup-config.sub
+++ b/autosetup/autosetup-config.sub
@@ -148,7 +148,7 @@ case $os in
 	-convergent* | -ncr* | -news | -32* | -3600* | -3100* | -hitachi* |\
 	-c[123]* | -convex* | -sun | -crds | -omron* | -dg | -ultra | -tti* | \
 	-harris | -dolphin | -highlevel | -gould | -cbm | -ns | -masscomp | \
-	-apple | -axis | -knuth | -cray | -microblaze*)
+	-axis | -knuth | -cray | -microblaze*)
 		os=
 		basic_machine=$1
 		;;
@@ -522,10 +522,6 @@ case $basic_machine in
 		;;
 	asmjs)
 		basic_machine=asmjs-unknown
-		;;
-	aux)
-		basic_machine=m68k-apple
-		os=-aux
 		;;
 	balance)
 		basic_machine=ns32k-sequent
@@ -1301,12 +1297,6 @@ case $basic_machine in
 	orion105)
 		basic_machine=clipper-highlevel
 		;;
-	mac | mpw | mac-mpw)
-		basic_machine=m68k-apple
-		;;
-	pmac | pmac-mpw)
-		basic_machine=powerpc-apple
-		;;
 	*-unknown)
 		# Make sure to match an already-canonicalized machine name.
 		;;
@@ -1700,9 +1690,6 @@ case $basic_machine in
 	*-*bug)
 		os=-coff
 		;;
-	*-apple)
-		os=-macos
-		;;
 	*-atari*)
 		os=-mint
 		;;
@@ -1766,14 +1753,8 @@ case $basic_machine in
 			-vxsim* | -vxworks* | -windiss*)
 				vendor=wrs
 				;;
-			-aux*)
-				vendor=apple
-				;;
 			-hms*)
 				vendor=hitachi
-				;;
-			-mpw* | -macos*)
-				vendor=apple
 				;;
 			-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
 				vendor=atari

--- a/autosetup/cc-shared.tcl
+++ b/autosetup/cc-shared.tcl
@@ -39,20 +39,6 @@ define STRIPLIBFLAGS --strip-unneeded
 #       http://sourceforge.net/apps/mediawiki/predef/index.php?title=Compilers
 
 switch -glob -- [get-define host] {
-	*-*-darwin* {
-		define SHOBJ_CFLAGS "-dynamic -fno-common"
-		define SHOBJ_LDFLAGS "-bundle -undefined dynamic_lookup"
-		define SHOBJ_LDFLAGS_R -bundle
-		define SH_CFLAGS -dynamic
-		define SH_LDFLAGS -dynamiclib
-		define SH_LINKFLAGS ""
-		define SH_SOEXT .dylib
-		define SH_SOEXTVER .%s.dylib
-		define SH_SOPREFIX -Wl,-install_name,
-		define SH_SOFULLPATH
-		define LD_LIBRARY_PATH DYLD_LIBRARY_PATH
-		define STRIPLIBFLAGS -x
-	}
 	*-*-ming* - *-*-cygwin - *-*-msys {
 		define SHOBJ_CFLAGS ""
 		define SHOBJ_LDFLAGS -shared

--- a/autosetup/cc.tcl
+++ b/autosetup/cc.tcl
@@ -718,16 +718,6 @@ if {[get-define CXX] ne "false"} {
 }
 msg-result "Build C compiler...[get-define CC_FOR_BUILD]"
 
-# On Darwin, we prefer to use -g0 to avoid creating .dSYM directories
-# but some compilers may not support it, so test here.
-switch -glob -- [get-define host] {
-	*-*-darwin* {
-		if {[cctest -cflags {-g0}]} {
-			define cc-default-debug -g0
-		}
-	}
-}
-
 if {![cc-check-includes stdlib.h]} {
 	user-error "Compiler does not work. See config.log"
 }

--- a/external/include/mum.h
+++ b/external/include/mum.h
@@ -148,10 +148,6 @@ _mum (uint64_t v, uint64_t p) {
 #if defined(_MSC_VER)
 #define _mum_bswap_32(x) _byteswap_uint32_t (x)
 #define _mum_bswap_64(x) _byteswap_uint64_t (x)
-#elif defined(__APPLE__)
-#include <libkern/OSByteOrder.h>
-#define _mum_bswap_32(x) OSSwapInt32 (x)
-#define _mum_bswap_64(x) OSSwapInt64 (x)
 #elif defined(__GNUC__)
 #define _mum_bswap32(x) __builtin_bswap32 (x)
 #define _mum_bswap64(x) __builtin_bswap64 (x)

--- a/external/libelf/_elftc.h
+++ b/external/libelf/_elftc.h
@@ -216,7 +216,7 @@ struct name {							\
 #define	ELFTC_VCSID(ID)		__FBSDID(ID)
 #endif
 
-#if defined(__linux__) || defined(__GNU__) || defined(__GLIBC__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)
 #if defined(__GNUC__)
 #define	ELFTC_VCSID(ID)		__asm__(".ident\t\"" ID "\"")
 #else
@@ -253,7 +253,7 @@ struct name {							\
 #ifndef	ELFTC_GETPROGNAME
 
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__minix) || \
-    defined(__NetBSD__) || defined(__APPLE__)
+    defined(__NetBSD__)
 
 #include <stdlib.h>
 
@@ -351,15 +351,12 @@ extern const char *__progname;
 #endif	/* __minix */
 
 
-#if defined(__NetBSD__) || defined(__APPLE__)
+#if defined(__NetBSD__)
 
 #include <sys/param.h>
-#ifndef __APPLE__
 #include <sys/endian.h>
-#else
 #include <machine/endian.h>
 #define	roundup2	roundup
-#endif
 
 #define	ELFTC_BYTE_ORDER			_BYTE_ORDER
 #define	ELFTC_BYTE_ORDER_LITTLE_ENDIAN		_LITTLE_ENDIAN

--- a/external/libelf/_libelf_config.h
+++ b/external/libelf/_libelf_config.h
@@ -26,7 +26,7 @@
  * $Id$
  */
 
-#if defined(__APPLE__) || defined(__DragonFly__)
+#if defined(__DragonFly__)
 
 #if	defined(__amd64__)
 #define	LIBELF_ARCH		EM_X86_64

--- a/external/libmachista/libmachista.c
+++ b/external/libmachista/libmachista.c
@@ -34,8 +34,6 @@
 #include <pkg_config.h>
 #endif
 
-/* required for asprintf(3) on OS X */
-#define _DARWIN_C_SOURCE
 /* required for asprintf(3) on Linux */
 #define _GNU_SOURCE
 

--- a/external/libucl/src/mum.h
+++ b/external/libucl/src/mum.h
@@ -148,10 +148,6 @@ _mum (uint64_t v, uint64_t p) {
 #if defined(_MSC_VER)
 #define _mum_bswap_32(x) _byteswap_uint32_t (x)
 #define _mum_bswap_64(x) _byteswap_uint64_t (x)
-#elif defined(__APPLE__)
-#include <libkern/OSByteOrder.h>
-#define _mum_bswap_32(x) OSSwapInt32 (x)
-#define _mum_bswap_64(x) OSSwapInt64 (x)
 #elif defined(__GNUC__)
 #define _mum_bswap32(x) __builtin_bswap32 (x)
 #define _mum_bswap64(x) __builtin_bswap64 (x)

--- a/external/libucl/tests/test_speed.c
+++ b/external/libucl/tests/test_speed.c
@@ -31,12 +31,6 @@
 #include <fcntl.h>
 #include <time.h>
 
-#ifdef __APPLE__
-#ifdef HAVE_MACH_MACH_TIME_H
-#include <mach/mach_time.h>
-#endif
-#endif
-
 #include "ucl.h"
 
 static double
@@ -44,14 +38,10 @@ get_ticks (void)
 {
 	double res;
 
-#ifdef __APPLE__
-	res = mach_absolute_time () / 1000000000.;
-#else
 	struct timespec ts;
 	clock_gettime (CLOCK_MONOTONIC, &ts);
 
 	res = (double)ts.tv_sec + ts.tv_nsec / 1000000000.;
-#endif
 
 	return res;
 }

--- a/external/lua/Makefile
+++ b/external/lua/Makefile
@@ -36,7 +36,7 @@ RM= rm -f
 # == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
 
 # Convenience platforms targets.
-PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+PLATS= guess aix bsd c89 freebsd generic linux linux-readline mingw posix solaris
 
 # What to install.
 TO_BIN= lua luac

--- a/external/lua/doc/readme.html
+++ b/external/lua/doc/readme.html
@@ -121,7 +121,7 @@ The <TT>Makefile</TT> there controls both the build process and the installation
   The platforms currently supported are:
 <P>
 <P CLASS="display">
-   guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+   guess aix bsd c89 freebsd generic linux linux-readline mingw posix solaris
 </P>
 <P>
   If your platform is listed, just do "<KBD>make xxx</KBD>", where xxx

--- a/external/lua/src/Makefile
+++ b/external/lua/src/Makefile
@@ -30,7 +30,7 @@ CMCFLAGS=
 
 # == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
 
-PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+PLATS= guess aix bsd c89 freebsd generic linux linux-readline mingw posix solaris
 
 LUA_A=	liblua.a
 CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
@@ -124,9 +124,6 @@ linux-noreadline:
 
 linux-readline:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE" SYSLIBS="-Wl,-E -ldl -lreadline"
-
-Darwin macos macosx:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
 
 mingw:
 	$(MAKE) "LUA_A=lua54.dll" "LUA_T=lua.exe" \

--- a/external/lua/src/luaconf.h
+++ b/external/lua/src/luaconf.h
@@ -64,12 +64,6 @@
 #endif
 
 
-#if defined(LUA_USE_MACOSX)
-#define LUA_USE_POSIX
-#define LUA_USE_DLOPEN		/* MacOS does not need -ldl */
-#endif
-
-
 /*
 @@ LUAI_IS32INT is true iff 'int' has (at least) 32 bits.
 */

--- a/external/sqlite/shell.c
+++ b/external/sqlite/shell.c
@@ -20267,6 +20267,9 @@ static void output_reset(ShellState *p){
       const char *zXdgOpenCmd =
 #if defined(_WIN32)
       "start";
+#elif defined(__APPLE__)
+      "open";
+#else
       "xdg-open";
 #endif
       char *zCmd;

--- a/external/sqlite/shell.c
+++ b/external/sqlite/shell.c
@@ -20267,9 +20267,6 @@ static void output_reset(ShellState *p){
       const char *zXdgOpenCmd =
 #if defined(_WIN32)
       "start";
-#elif defined(__APPLE__)
-      "open";
-#else
       "xdg-open";
 #endif
       char *zCmd;

--- a/libpkg/lua.c
+++ b/libpkg/lua.c
@@ -236,15 +236,10 @@ lua_pkg_copy(lua_State *L)
 	ts[0] = s1.st_atim;
 	ts[1] = s1.st_mtim;
 #else
-#if defined(_DARWIN_C_SOURCE) || defined(__APPLE__)
-	ts[0] = s1.st_atimespec;
-	ts[1] = s1.st_mtimespec;
-#else
 	ts[0].tv_sec = s1.st_atime;
 	ts[0].tv_nsec = 0;
 	ts[1].tv_sec = s1.st_mtime;
 	ts[1].tv_nsec = 0;
-#endif
 #endif
 
 	if (set_attrsat(rootfd, RELATIVE_PATH(dst), s1.st_mode, s1.st_uid,

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -295,19 +295,12 @@ fill_timespec_buf(const struct stat *aest, struct timespec tspec[2])
 	tspec[1].tv_sec = aest->st_mtim.tv_sec;
 	tspec[1].tv_nsec = aest->st_mtim.tv_nsec;
 #else
-# if defined(_DARWIN_C_SOURCE) || defined(__APPLE__)
-	tspec[0].tv_sec = aest->st_atimespec.tv_sec;
-	tspec[0].tv_nsec = aest->st_atimespec.tv_nsec;
-	tspec[1].tv_sec = aest->st_mtimespec.tv_sec;
-	tspec[1].tv_nsec = aest->st_mtimespec.tv_nsec;
-# else
 	/* Portable unix version */
 	tspec[0].tv_sec = aest->st_atime;
 	tspec[0].tv_nsec = 0;
 	tspec[1].tv_sec = aest->st_mtime;
 	tspec[1].tv_nsec = 0;
 # endif
-#endif
 }
 
 static void
@@ -1581,15 +1574,10 @@ pkg_add_fromdir(struct pkg *pkg, const char *src)
 		d->time[0] = st.st_atim;
 		d->time[1] = st.st_mtim;
 #else
-#if defined(_DARWIN_C_SOURCE) || defined(__APPLE__)
-		d->time[0] = st.st_atimespec;
-		d->time[1] = st.st_mtimespec;
-#else
 		d->time[0].tv_sec = st.st_atime;
 		d->time[0].tv_nsec = 0;
 		d->time[1].tv_sec = st.st_mtime;
 		d->time[1].tv_nsec = 0;
-#endif
 #endif
 
 		if (create_dir(pkg, d, &tempdirs) == EPKG_FATAL) {
@@ -1643,15 +1631,10 @@ pkg_add_fromdir(struct pkg *pkg, const char *src)
 		f->time[0] = st.st_atim;
 		f->time[1] = st.st_mtim;
 #else
-#if defined(_DARWIN_C_SOURCE) || defined(__APPLE__)
-		f->time[0] = st.st_atimespec;
-		f->time[1] = st.st_mtimespec;
-#else
 		f->time[0].tv_sec = st.st_atime;
 		f->time[0].tv_nsec = 0;
 		f->time[1].tv_sec = st.st_mtime;
 		f->time[1].tv_nsec = 0;
-#endif
 #endif
 
 		if (S_ISLNK(st.st_mode)) {

--- a/libpkg/pkg_macho.c
+++ b/libpkg/pkg_macho.c
@@ -223,7 +223,7 @@ host_cpu_type(cpu_type_t *result)
 /**
  * Fetch the OS name and major version.
  *
- * @param osname On success, the OS name (e.g. Darwin).
+ * @param osname On success, the OS name (e.g. NQC).
  * @param sz The maximum number of bytes to be written to osname.
  * @param major_version On success, the major version of the host.
  */

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -57,9 +57,7 @@ install_from_github() {
 	rm -rf "${distname}" "${distname}.tar.gz"
 }
 
-if [ $(uname -s) = "Darwin" ]; then
-	brew install libarchive kyua coreutils
-elif [ $(uname -s) = "Linux" ]; then
+if [ $(uname -s) = "Linux" ]; then
 	install_from_github atf 0.21
 	install_from_github lutok 0.4
 	install_from_github kyua 0.12

--- a/scripts/travis_build.sh
+++ b/scripts/travis_build.sh
@@ -36,12 +36,7 @@
 set -x
 set -e
 
-if [ $(uname -s) = "Darwin" ]; then
-  export LDFLAGS="-L/usr/local/opt/libarchive/lib"
-  export CPPFLAGS="-I/usr/local/opt/libarchive/include"
-  export CFLAGS="-I/usr/local/opt/libarchive/include"
-  ./configure
-elif [ $(uname -s) = "Linux" ]; then
+if [ $(uname -s) = "Linux" ]; then
   CFLAGS="-Wno-strict-aliasing -Wno-unused-result -Wno-unused-value" ./configure --with-libarchive.pc
 else
   ./configure

--- a/tests/frontend/abi.sh
+++ b/tests/frontend/abi.sh
@@ -7,13 +7,8 @@ tests_init \
 basic_body() {
 	_uname_s="$(uname -s)"
 	_expected="TODO: implement me"
-	if [ "${_uname_s}" = "Darwin" ]; then
-			# The FreeBSD ELF ABI_FILE should is ignored on non-ELF platforms:
-		_expected="${_uname_s}:$(uname -r | cut -d. -f1):$(uname -p)\n"
-	else
 		# Otherwise the ABI should be parsed from the ELF file.
 		_expected="FreeBSD:13:amd64\n"
-	fi
 	atf_check \
 		-o inline:"${_expected}" \
 		pkg -o IGNORE_OSMAJOR=1 -o ABI_FILE=$(atf_get_srcdir)/fbsd.bin config abi


### PR DESCRIPTION
Remove Apple support from PKG. Nevuqe's version of PKG is for exclusive usage on FreeBSD/NQC